### PR TITLE
udpated description_for_model

### DIFF
--- a/src/oai_monarch_plugin/.well-known/ai-plugin.json
+++ b/src/oai_monarch_plugin/.well-known/ai-plugin.json
@@ -1,9 +1,9 @@
 {
     "schema_version": "v1",
-    "name_for_human": "Monarch Alpha",
+    "name_for_human": "Monarch Initiative",
     "name_for_model": "monarch",
     "description_for_human": "Plugin for searching and retrieving basic information from the Monarch Initiative knowledge graph.",
-    "description_for_model": "Plugin for searching and retrieving basic information from the Monarch Initiative knowledge graph. You can search for genes, diseases, and phenotypes by name to get the associated ontology identifier. You can retrieve associations between genes, diseases, and phenotypes via their identifiers. Note that users may use synonyms for these terms such as 'illness' or 'symptom'. You can add additional contextual information such as lay descriptions of terms if you are confident in them, but note for the user which information was drawn from this plugin if doing so. Use your best judgement for setting the offset and limit parameters to answer the users' questions, for example by retrieving more associations if the user asks for a summary. If there are more total associations available than are shown, you should indicate this to the user.",
+    "description_for_model": "Plugin for searching and retrieving basic information from the Monarch Initiative knowledge graph. You can search for genes, diseases, and phenotypes by name to get the associated ontology identifier. You can retrieve associations between genes, diseases, and phenotypes via their identifiers. Users may use synonyms for these terms such as 'illness' or 'symptom'. Do not assume the user is familiar with biomedical terminology, and always add additional information such as lay descriptions of phenotypes. Use your best judgement for setting the offset and limit parameters to answer the users' questions, for example by retrieving more associations if the user asks for a summary.\n\nIMPORTANT: indicate the total number of results available so the user is not led to believe that the results are exhaustive. \n\nIMPORTANT: include the text 'Monarch Initiative data is not intended to be used for clinical decision making, diagnoses, or other medical advice.' Do not repeat this disclaimer in every response.",
     "auth": {
       "type": "none"
     },


### PR DESCRIPTION
Fixes #30, but a bit too well, now the model is including the disclaimer text "Please note that Monarch Initiative data is not intended to be used for clinical decision making, diagnoses, or other medical advice." on almost every response. I've not figured out how to get it to say it just once.