### PR TITLE
Entities search

### DIFF
--- a/src/oai_monarch_plugin/main.py
+++ b/src/oai_monarch_plugin/main.py
@@ -19,6 +19,7 @@ from .routers import (
     phenotype_to_disease,
     phenotype_to_gene,
     search,
+    entity
 )
 
 # setup base app
@@ -47,6 +48,7 @@ app.mount("/static", StaticFiles(directory=dirname(abspath(__file__)) + "/static
 
 # setup routers
 app.include_router(search.router)
+app.include_router(entity.router)
 app.include_router(disease_to_gene.router)
 app.include_router(disease_to_phenotype.router)
 app.include_router(gene_to_disease.router)

--- a/src/oai_monarch_plugin/routers/entity.py
+++ b/src/oai_monarch_plugin/routers/entity.py
@@ -14,9 +14,9 @@ router = APIRouter()
 @router.get(
     "/entity",
     response_model=List[Entity],
-    description="Get information about entities",
-    summary="Get information about entities",
-    response_description="Information about the entities",
+    description="Get information about arbitrary entities by identifier, e.g. MONDO:0005737, HP:0002721, HGNC:1884.",
+    summary="Returns information on entities such as name, description, synonyms, categories, and counts of associations to other entities of different types.",
+    response_description="A JSON array of entity descriptors.",
     operation_id="get_entities",
 )
 async def get_entities(ids: List[str] = Query(..., description="List of entity ids")) -> List[Entity]:
@@ -35,6 +35,21 @@ async def get_entities(ids: List[str] = Query(..., description="List of entity i
 
             response_json = response.json()
 
-            entities.append(Entity(**response_json))
+            id = response_json.get("id")
+            category = response_json.get("category")
+            name = response_json.get("name")
+            description = response_json.get("description")
+            symbol = response_json.get("symbol")
+            synonym = response_json.get("synonym")
+
+            association_counts_json = response_json.get("association_counts")
+            association_counts = []
+            for association_count_json in association_counts_json:
+                association_count: AssociationCount = AssociationCount(label = association_count_json.get("label"), 
+                                                                       count = association_count_json.get("count"))
+                association_counts.append(association_count)
+
+            
+            entities.append(Entity(id=id, category=category, name=name, description=description, symbol=symbol, synonym=synonym, association_counts=association_counts))
             
     return entities

--- a/src/oai_monarch_plugin/routers/entity.py
+++ b/src/oai_monarch_plugin/routers/entity.py
@@ -1,0 +1,40 @@
+from typing import List
+
+import httpx
+from fastapi import APIRouter, Query
+from loguru import logger
+
+from .config import settings
+from .models import *
+
+BASE_API_URL = settings.monarch_api_url
+
+router = APIRouter()
+
+@router.get(
+    "/entity",
+    response_model=List[Entity],
+    description="Get information about entities",
+    summary="Get information about entities",
+    response_description="Information about the entities",
+    operation_id="get_entities",
+)
+async def get_entities(ids: List[str] = Query(..., description="List of entity ids")) -> List[Entity]:
+    entities = []
+    async with httpx.AsyncClient() as client:
+        for id in ids:
+            api_url = f"{BASE_API_URL}/entity/{id}"
+            logger.info({
+                "event": "monarch_api_call",
+                "url": str(client.build_request("GET", api_url).url),
+                "api_url": api_url,
+                "method": "GET"
+            })
+
+            response = await client.get(api_url)
+
+            response_json = response.json()
+
+            entities.append(Entity(**response_json))
+            
+    return entities

--- a/src/oai_monarch_plugin/routers/models.py
+++ b/src/oai_monarch_plugin/routers/models.py
@@ -82,9 +82,9 @@ class AssociationCount(BaseModel):
 
 class Entity(BaseModel):
     id: str = Field(..., description="The ontology identifier of the entity.", example="MONDO:0009061")
-    category: str = Field(..., description="The category of the entity.", example="biolink:Disease")
-    name: str = Field(..., description="The human-readable label of the entity.", example="cystic fibrosis")
+    category: List[str] = Field(..., description="The categories of the entity.", example=["biolink:Disease"])
+    name: Optional[str] = Field(None, description="The human-readable label of the entity.", example="cystic fibrosis")
     description: Optional[str] = Field(None, description="The description of the entity.")
-    symbol: Optional[str] = None
-    synonym: List = []
-    association_counts: List[AssociationCount]
+    symbol: Optional[str] = Field(None, description="The symbol of the entity, usually a short name like FBN1.")
+    synonym: List[str] = Field(..., description="The synonyms of the entity.")
+    association_counts: List[AssociationCount] = Field(..., description="Counts of associations between this entity and other entities of different types.")

--- a/src/oai_monarch_plugin/routers/models.py
+++ b/src/oai_monarch_plugin/routers/models.py
@@ -70,3 +70,21 @@ class GeneAssociations(BaseModel):
     )
     total: int = Field(..., description="The total number of gene associations available.")
     gene_url_template: str = Field(..., description="URL template for constructing links to the Monarch Initiative website.")
+
+
+
+
+
+class AssociationCount(BaseModel):
+    label: str = Field(..., description="The type of the associations (e.g. Disease or Gene)", example="Causal")
+    count: int = Field(..., description="The number of associations of that type.")
+
+
+class Entity(BaseModel):
+    id: str = Field(..., description="The ontology identifier of the entity.", example="MONDO:0009061")
+    category: str = Field(..., description="The category of the entity.", example="biolink:Disease")
+    name: str = Field(..., description="The human-readable label of the entity.", example="cystic fibrosis")
+    description: Optional[str] = Field(None, description="The description of the entity.")
+    symbol: Optional[str] = None
+    synonym: List = []
+    association_counts: List[AssociationCount]

--- a/src/oai_monarch_plugin/routers/search.py
+++ b/src/oai_monarch_plugin/routers/search.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 import httpx
 from fastapi import APIRouter, Query

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -21,6 +21,25 @@ def test_search_endpoint():
         assert "description" in result
 
 
+def test_get_entities_endpoint():
+    response = test_client.get("/entity?ids=MONDO:0005148&ids=MONDO:0009061")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 2
+
+    for entity in data:
+        assert "id" in entity
+        assert "category" in entity
+        assert "name" in entity
+        assert "description" in entity
+        assert "association_counts" in entity
+
+        for association_count in entity["association_counts"]:
+            assert "label" in association_count
+            assert "count" in association_count
+
+
 def test_gene_to_phenotype():
     response = test_client.get("/gene-phenotypes?gene_id=HGNC:1884&limit=2")
 


### PR DESCRIPTION
Fixes #37 by adding an /entities endpoint which looks up name, symbol, synonyms, reference counts, and other metadata in bulk.