### PR TITLE
put prod hostname in ai-plugin.json

### DIFF
--- a/src/oai_monarch_plugin/.well-known/ai-plugin.json
+++ b/src/oai_monarch_plugin/.well-known/ai-plugin.json
@@ -9,10 +9,10 @@
     },
     "api": {
       "type": "openapi",
-      "url": "http://localhost:3434/openapi.json",
+      "url": "https://oai-monarch-plugin.monarchinitiative.org/openapi.json",
       "is_user_authenticated": false
     },
-    "logo_url": "http://localhost:3434/static/logo.png",
+    "logo_url": "https://oai-monarch-plugin.monarchinitiative.org/static/logo.png",
     "contact_email": "shawn@tislab.org",
     "legal_info_url": "https://monarchinitiative.org/about/disclaimer"
   }


### PR DESCRIPTION
Fixes #44 . I do wonder though, what's the best workflow for development? Probably should generate ai-plugin.json and set the hostname from an environment var I guess.