### PR TITLE
Model metadata

### DIFF
--- a/src/oai_monarch_plugin/routers/disease_to_gene.py
+++ b/src/oai_monarch_plugin/routers/disease_to_gene.py
@@ -55,7 +55,7 @@ async def get_disease_gene_associations(
             gene_id=item.get("subject"),
             label=item.get("subject_label"),
         )
-        assoc = GeneAssociation(gene=gene, type="causal")
+        assoc = GeneAssociation(gene=gene, metadata={"relationship": "causal"})
         associations.append(assoc)
 
     for item in correlatedAssociations.get("items", []):
@@ -64,7 +64,7 @@ async def get_disease_gene_associations(
             gene_id=item.get("subject"),
             label=item.get("subject_label"),
         )
-        assoc = GeneAssociation(gene=gene, type="correlated")
+        assoc = GeneAssociation(gene=gene, metadata={"relationship": "correlated"})
         associations.append(assoc)
 
     return GeneAssociations(associations = associations, 

--- a/src/oai_monarch_plugin/routers/disease_to_phenotype.py
+++ b/src/oai_monarch_plugin/routers/disease_to_phenotype.py
@@ -43,8 +43,7 @@ async def get_disease_phenotype_associations(
     for item in genericAssociations.get("items", []):
         phenotype = Phenotype(phenotype_id=item.get("object"), label=item.get("object_label"))
         assoc = PhenotypeAssociation(
-            frequency_qualifier=item.get("frequency_qualifier"),
-            onset_qualifier=item.get("onset_qualifier"),
+            metadata = {"frequency_qualifier": item.get("frequency_qualifier"), "onset_qualifier": item.get("onset_qualifier")},
             phenotype=phenotype
         )
         associations.append(assoc)

--- a/src/oai_monarch_plugin/routers/entity.py
+++ b/src/oai_monarch_plugin/routers/entity.py
@@ -50,6 +50,6 @@ async def get_entities(ids: List[str] = Query(..., description="List of entity i
                 association_counts.append(association_count)
 
             
-            entities.append(Entity(id=id, category=category, name=name, description=description, symbol=symbol, synonym=synonym, association_counts=association_counts))
+            entities.append(Entity(id=id, category=[category], name=name, description=description, symbol=symbol, synonym=synonym, association_counts=association_counts))
             
     return entities

--- a/src/oai_monarch_plugin/routers/gene_to_disease.py
+++ b/src/oai_monarch_plugin/routers/gene_to_disease.py
@@ -49,12 +49,12 @@ async def get_gene_disease_associations(
     associations = []
     for item in causalAssociations.get("items", []):
         disease = Disease(disease_id=item.get("object"), label=item.get("object_label"), type="causal")
-        assoc = DiseaseAssociation(disease=disease)
+        assoc = DiseaseAssociation(disease=disease, metadata={"relationship": "causal"})
         associations.append(assoc)
 
     for item in correlatedAssociations.get("items", []):
-        disease = Disease(disease_id=item.get("object"), label=item.get("object_label"), type="correlated")
-        assoc = DiseaseAssociation(disease=disease)
+        disease = Disease(disease_id=item.get("object"), label=item.get("object_label"))
+        assoc = DiseaseAssociation(disease=disease, metadata={"relationship": "correlated"})
         associations.append(assoc)
 
     return DiseaseAssociations(associations=associations, 

--- a/src/oai_monarch_plugin/routers/gene_to_phenotype.py
+++ b/src/oai_monarch_plugin/routers/gene_to_phenotype.py
@@ -46,8 +46,7 @@ async def get_gene_phenotype_associations(
             label=item.get("object_label")
         )
         assoc = PhenotypeAssociation(
-            frequency_qualifier=item.get("frequency_qualifier"),
-            onset_qualifier=item.get("onset_qualifier"),
+            metadata = {"frequency_qualifier": item.get("frequency_qualifier"), "onset_qualifier": item.get("onset_qualifier")},
             phenotype=phenotype,
         )
         associations.append(assoc)

--- a/src/oai_monarch_plugin/routers/models.py
+++ b/src/oai_monarch_plugin/routers/models.py
@@ -7,8 +7,11 @@ from pydantic import BaseModel, Field
 class PublicationBacked(BaseModel):
     publications: List[Dict[str, str]] = Field([], description="List of related publications and associated metadata.")
 
+class HasMetadata(BaseModel):
+    metadata: Dict[str, Any] = Field({}, description="Other metadata associaciated with the entity or association.")
 
-class Phenotype(PublicationBacked):
+
+class Phenotype(PublicationBacked, HasMetadata):
     phenotype_id: str = Field(
         ..., description="The ontology identifier of the phenotype.", example="HP:0002721"
     )
@@ -17,13 +20,13 @@ class Phenotype(PublicationBacked):
     )
 
 
-class PhenotypeAssociation(PublicationBacked):
-    frequency_qualifier: Optional[str] = Field(
-        None, description="The frequency qualifier of the association."
-    )
-    onset_qualifier: Optional[str] = Field(
-        None, description="The onset qualifier of the association."
-    )
+class PhenotypeAssociation(PublicationBacked, HasMetadata):
+    # frequency_qualifier: Optional[str] = Field(
+    #     None, description="The frequency qualifier of the association."
+    # )
+    # onset_qualifier: Optional[str] = Field(
+    #     None, description="The onset qualifier of the association."
+    # )
     phenotype: Phenotype
 
 
@@ -35,7 +38,7 @@ class PhenotypeAssociations(BaseModel):
     phenotype_url_template: str = Field(..., description="URL template for constructing links to the Monarch Initiative website.", example="https://monarchinitiative.org/phenotype/{phenotype_id}")
 
 
-class Disease(PublicationBacked):
+class Disease(PublicationBacked, HasMetadata):
     disease_id: str = Field(
         ..., description="The ontology identifier of the disease.", example="MONDO:0009061"
     )
@@ -44,7 +47,7 @@ class Disease(PublicationBacked):
     )
 
 
-class DiseaseAssociation(PublicationBacked):
+class DiseaseAssociation(PublicationBacked, HasMetadata):
     disease: Disease = Field(..., description="The Disease object.")
     type: Optional[str] = Field(
         None, description="The type of the association (causal or correlated)."
@@ -59,12 +62,12 @@ class DiseaseAssociations(BaseModel):
     disease_url_template: str = Field(..., description="URL template for constructing links to the Monarch Initiative website.", example="https://monarchinitiative.org/disease/{disease_id}")
 
 
-class Gene(PublicationBacked):
+class Gene(PublicationBacked, HasMetadata):
     gene_id: str = Field(..., description="The ontology identifier of the gene.", example="HGNC:1884")
     label: str = Field(..., description="The human-readable label of the gene.", example="CFTR")
 
 
-class GeneAssociation(PublicationBacked):
+class GeneAssociation(PublicationBacked, HasMetadata):
     gene: Gene
 
 
@@ -76,15 +79,12 @@ class GeneAssociations(BaseModel):
     gene_url_template: str = Field(..., description="URL template for constructing links to the Monarch Initiative website.", example="https://monarchinitiative.org/gene/{gene_id}")
 
 
-
-
-
 class AssociationCount(BaseModel):
     label: str = Field(..., description="The type of the associations (e.g. Disease or Gene)", example="Causal")
     count: int = Field(..., description="The number of associations of that type.")
 
 
-class Entity(PublicationBacked):
+class Entity(PublicationBacked, HasMetadata):
     id: str = Field(..., description="The ontology identifier of the entity.", example="MONDO:0009061")
     category: List[str] = Field(..., description="The categories of the entity.", example=["biolink:Disease"])
     name: Optional[str] = Field(None, description="The human-readable label of the entity.", example="cystic fibrosis")

--- a/src/oai_monarch_plugin/routers/search.py
+++ b/src/oai_monarch_plugin/routers/search.py
@@ -78,7 +78,7 @@ async def search_entity(
             SearchResultItem(
                 id=item.get("id"),
                 name=item.get("name"),
-                categories=item.get("category"),
+                categories=[item.get("category")],
                 description=item.get("description"),
             )
         )

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -80,8 +80,9 @@ def test_gene_to_phenotype():
 
     # Check structure of each association
     for association in data["associations"]:
-        assert "frequency_qualifier" in association
-        assert "onset_qualifier" in association
+        assert "metadata" in association
+        assert "onset_qualifier" in association["metadata"]
+        assert "frequency_qualifier" in association["metadata"]
         assert "phenotype" in association
         assert "phenotype_id" in association["phenotype"]
         assert "label" in association["phenotype"]
@@ -137,8 +138,9 @@ def test_disease_to_phenotype():
 
     # Check structure of each association
     for association in data["associations"]:
-        assert "frequency_qualifier" in association
-        assert "onset_qualifier" in association
+        assert "metadata" in association
+        assert "onset_qualifier" in association["metadata"]
+        assert "frequency_qualifier" in association["metadata"]
         assert "phenotype" in association
         assert "phenotype_id" in association["phenotype"]
         assert "label" in association["phenotype"]


### PR DESCRIPTION
Moves some association metadata into a metadata subfield with generic description, which will allow modifying/adding association metadata without changing the API and triggering a review by OpenAI (which pulls the existing plugin down from the store while the review is in progress, [ugh](https://community.openai.com/t/process-for-updating-plugins/221956)). Related to #41 .